### PR TITLE
Fix contact form 404 and collect full shipping info

### DIFF
--- a/src/components/thanks/EmailForm.astro
+++ b/src/components/thanks/EmailForm.astro
@@ -74,17 +74,63 @@ const newsletterChecked =
             error={errors?.quantity}
           />
           <Input
+            name='organization'
+            title='Organization (optional)'
+            autocomplete='organization'
+            value={formData?.organization ?? ''}
+            error={errors?.organization}
+          />
+          <Input
+            name='phone'
+            type='tel'
+            autocomplete='tel'
+            required
+            value={formData?.phone ?? ''}
+            error={errors?.phone}
+          />
+          <Input
+            name='address'
+            title='street 1'
+            autocomplete='address-line1'
+            required
+            value={formData?.address ?? ''}
+            error={errors?.address}
+          />
+          <Input
+            name='address2'
+            title='street 2'
+            autocomplete='address-line2'
+            value={formData?.address2 ?? ''}
+            error={errors?.address2}
+          />
+          <Input
+            name='zip'
+            title='zip code'
+            autocomplete='postal-code'
+            required
+            value={formData?.zip ?? ''}
+            error={errors?.zip}
+          />
+          <Input
+            name='city'
+            autocomplete='address-level2'
+            required
+            value={formData?.city ?? ''}
+            error={errors?.city}
+          />
+          <Input
+            name='region'
+            autocomplete='address-level1'
+            value={formData?.region ?? ''}
+            error={errors?.region}
+          />
+          <Input
             name='country'
             title='Country'
+            autocomplete='country'
             required
             value={formData?.country ?? ''}
             error={errors?.country}
-          />
-          <Input
-            name='organization'
-            title='Organization (optional)'
-            value={formData?.organization ?? ''}
-            error={errors?.organization}
           />
           <label
             for='request-message'
@@ -98,9 +144,8 @@ const newsletterChecked =
               class='w-full bg-transparent py-3 px-4.5 border placeholder:text-gray-dark rounded-xl'
               class:list={[errors?.message ? 'border-red' : 'border-gray']}
               placeholder='Share any delivery notes or details'
-            >
-              {formData?.message ?? ''}
-            </textarea>
+              set:text={formData?.message ?? ''}
+            />
             <p class='text-xs text-red'>{errors?.message?.message ?? <>&nbsp;</>}</p>
           </label>
         </>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -1,14 +1,19 @@
 ---
+export const prerender = false
+
 import {Icon} from 'astro-icon/components'
 import type {Icon as IconName} from 'virtual:astro-icon'
+import type {ZodIssue} from 'zod'
 import {FormSuccess} from '~components/thanks'
 import EmailForm from '~components/thanks/EmailForm.astro'
 import {contactLinks} from '~constants/navigation'
 import {Layout} from '~layouts'
-import {insertUser, insertUserSchema} from '~server/db'
+import {insertUser} from '~server/db'
 import {createContactSheetRow} from '~server/gsheet'
+import {cardRequestSchema} from '~utils/schemas'
 
-let formData
+let formData: Record<string, string> | undefined
+let errors: Record<string, ZodIssue> | undefined
 let confirmed = false
 
 // when form is posted
@@ -20,27 +25,42 @@ if (Astro.request.method === 'POST') {
       throw new Error('Bot detected')
     }
 
-    const parsedUser = insertUserSchema.parse({
-      name: formData.name,
-      email: formData.email,
-      newsletter: formData.newsletter === 'on',
-    })
+    const parsed = cardRequestSchema.safeParse(formData)
+    if (!parsed.success) {
+      errors = Object.fromEntries(
+        parsed.error.issues.map((issue) => [String(issue.path[0]), issue])
+      )
+    } else {
+      const request = parsed.data
 
-    const dbUser = await insertUser(parsedUser)
-    confirmed = true
+      await insertUser({
+        name: request.name,
+        email: request.email,
+        newsletter: request.newsletter ?? false,
+      })
 
-    // if (dbUser) {
-    await createContactSheetRow({
-      ...parsedUser,
-      requestType: 'cards',
-      quantity: formData.quantity ?? '',
-      country: formData.country ?? '',
-      organization: formData.organization ?? '',
-      message: formData.message ?? '',
-    })
-    // }
+      await createContactSheetRow({
+        name: request.name,
+        email: request.email,
+        newsletter: request.newsletter ?? false,
+        requestType: 'cards',
+        quantity: request.quantity,
+        organization: request.organization,
+        phone: request.phone,
+        address: request.address,
+        address2: request.address2,
+        zip: request.zip,
+        city: request.city,
+        region: request.region,
+        country: request.country,
+        message: request.message,
+      })
+
+      confirmed = true
+    }
   } catch (error) {
     console.error(error)
+    errors ??= {}
   }
 }
 ---
@@ -89,7 +109,7 @@ if (Astro.request.method === 'POST') {
           buttonLabel='Submit another request'
         />
       ) : (
-        <EmailForm mode='request' />
+        <EmailForm mode='request' formData={formData} errors={errors} />
       )
     }
   </div>

--- a/src/utils/schemas.ts
+++ b/src/utils/schemas.ts
@@ -22,6 +22,21 @@ export const countryString = z.string().transform((val, ctx) => {
   return country.code
 })
 
+export const cardRequestSchema = thankYouFormSchema.extend({
+  name: z.string().min(2, {message: 'Field is required'}),
+  email: z.string().email({message: 'A valid email is required'}),
+  quantity: z.coerce.number().int().min(1, {message: 'At least 1 deck is required'}),
+  organization: z.string().optional().default(''),
+  phone: z.string().regex(/^[\d\s()+-.]+$/, {message: 'Invalid phone number'}),
+  address: z.string().min(1, {message: 'Field is required'}),
+  address2: z.string().optional().default(''),
+  zip: z.string().min(1, {message: 'Field is required'}),
+  city: z.string().min(1, {message: 'Field is required'}),
+  region: z.string().optional().default(''),
+  country: countryString,
+  message: z.string().optional().default(''),
+})
+
 export const orderSchema = z.object({
   count: z.coerce.number().int(),
   priceId: z.string(),


### PR DESCRIPTION
## Summary
- Fix the 404 users hit after submitting the card request form: the site builds with `output: 'static'` and `contact.astro` was missing `export const prerender = false`, so the page was emitted as static HTML and Netlify had nothing to handle the POST.
- Make the form non-brittle: submissions are validated with a new `cardRequestSchema`; failures re-render the form with field-level errors and the user's input preserved instead of silently showing an empty form. `confirmed` is only set after both the DB insert and the Google Sheet row succeed.
- Collect full shipping info on the request form: phone, street 1/2, zip, city, region, country (same field set as the post-purchase shipping form), all forwarded to the contacts sheet.

Follow-up: #39 (send WhatsApp message on card request submission).

## Testing
- `pnpm build` passes; `dist/contact.html` is no longer emitted (page is SSR now).
- Dev-server smoke test: POST with invalid data returns 200 with field errors ("A valid email is required", "At least 1 deck is required", "A valid Country is required") and round-trips the entered values back into the form.