### PR TITLE
AI Check-In: question content (#56)

### DIFF
--- a/docs/strategy/ai-at-work.md
+++ b/docs/strategy/ai-at-work.md
@@ -1,0 +1,231 @@
+# WhoCards → "Navigating AI at Work": competitor analysis & product strategy
+
+_Prepared 2026-06-16. Goal: find a wedge that gets WhoCards traction and revenue by pointing
+its existing conversation-card engine at the single biggest unmet need in companies right now —
+helping people talk honestly about AI arriving in their jobs._
+
+---
+
+## 1. The thesis (one paragraph)
+
+Companies are spending heavily on AI but **adoption is stalling on the human layer, not the tech
+layer**. Roughly **38% of AI implementation difficulty is user proficiency/resistance vs ~16%
+technical**, and **88% of orgs use AI yet 62% are stuck in "experimenting/piloting."** Meanwhile
+**~65–89% of workers are anxious about AI and their jobs, and only ~38% feel supported** through
+the change. The market response so far is split into two extremes: cheap generic conversation
+decks ($18–30) that don't touch AI, and expensive top-down AI workshops/consulting ($1.2k–$150k)
+that are technical and rarely create psychological safety. **Nobody owns the honest-conversation
+layer of AI adoption.** WhoCards is already a "conversations that encourage honest self-expression,
+active listening, and deeper connection" engine. That is the exact bridge — and the product we're
+already building (accounts + custom decks + custom questions, issue #45) is the monetization
+vehicle.
+
+---
+
+## 2. Why now (the data)
+
+| Signal | Number | Source |
+|---|---|---|
+| Workers concerned about AI's impact on job security | **89%** (65% "anxious about being replaced") | Resume Now AI Disruption Report |
+| Employees who feel fully supported adapting to AI | only **38%** | SHRM State of AI in HR 2026 |
+| Workers confident using AI tools effectively | **35%** | Microsoft 2026 Work Trend Index |
+| Say employer is only "somewhat transparent" about AI plans | **54%** | EY / Gallup |
+| Orgs using AI in ≥1 function | **88%** | McKinsey-style adoption stats (Go1) |
+| …but stuck in "Experimenting/Piloting" | **62%** | Go1 AI training report |
+| Share of adoption difficulty that is **people**, not tech | **~38% proficiency vs ~16% technical** | Larridin enterprise guide |
+
+> ⚠️ **Stat verification:** these figures come from secondary summaries and need a primary-source check before anything goes on a public page. For public-facing copy, prefer the independently-verified set in the landing-copy deliverable (PR #58/#62): Pew (52% worried), Ivanti (~30% hide AI use), McKinsey (leader/employee adoption gap), Mercer (40% obsolescence fear). The "~38% feel supported" figure in particular could not be verified against a public source.
+
+**Read:** the buyer's pain is real, urgent, budgeted, and currently mis-served. When AI is framed
+only as "efficiency / do more with less," employees "don't hear opportunity, they hear threat."
+That emotional gap is conversational by nature — exactly WhoCards' home turf.
+
+---
+
+## 3. Competitor landscape
+
+Four clusters. WhoCards' opening is the empty middle.
+
+### Cluster A — Generic conversation / connection decks (consumer + light team)
+We're Not Really Strangers, TableTopics (incl. a "Team" edition), The School of Life, Actually
+Curious, We! Connect Cards (TEDx), Peelr (digital), The Unstuck Box, Best Self.
+- **Price:** ~$18–30 retail per deck.
+- **Strength:** brand, beautiful decks, proven format, emotional resonance.
+- **Weakness:** generic. None address AI/role-change. No org/recurring revenue motion; one-time
+  novelty purchase. This is the category WhoCards currently competes in — crowded, low margin.
+
+### Cluster B — Facilitation / workshop card decks (B2B practitioner)
+SessionLab "Workshops & Wizards," Foresight Cards, Synergy Stack, Trainers Warehouse decks.
+- **Buyer:** facilitators, L&D, agile coaches.
+- **Strength:** sold as professional tools, higher willingness to pay.
+- **Weakness:** method-focused, not emotion-focused; not AI-specific.
+
+### Cluster C — AI-specific learning tools (the new entrants)
+**AI Tinkerers' Cards**, GenAI "teach with cards" decks, plus AI-literacy LMS content (Go1, D2L,
+Judge, SAP Workforce Upskilling Assistant).
+- **Strength:** ride the AI wave; clearly timely.
+- **Weakness:** they teach **mechanics** ("what is a prompt, what is a token"). They do **not**
+  address fear, identity, trust, "what stays human," or team norms. They make people *capable*,
+  not *willing*.
+
+### Cluster D — AI adoption workshops & change-management consulting (high-touch, high-ticket)
+SmarterX (**$75k**/workshop), Connect Facilitation "AI Explore" (**€1,200 + VAT**, ≤30 ppl),
+Instinctools, Improving, Microsoft/Simform readiness workshops; change-mgmt consulting
+**£8k–£150k**; Moveworks/OCM/Robert Half playbooks.
+- **Strength:** big budgets, executive sponsorship.
+- **Weakness:** top-down, expensive, episodic. The honest peer-level conversation doesn't happen
+  in a $75k exec session — it happens in the team, repeatedly, and that's unserved.
+
+### The map
+
+```
+                         AI-SPECIFIC
+                              |
+        AI literacy LMS  •    |   • AI adoption workshops / consulting
+        (Go1, SAP)            |     ($1.2k–$150k, top-down, technical)
+   AI Tinkerers' cards •      |
+                              |
+                       >>>  THE GAP  <<<
+            honest, recurring, team-level conversation
+            about AI — psychological safety, not mechanics
+                              |
+   LOW-TOUCH / PRODUCT -------+------- HIGH-TOUCH / SERVICE
+                              |
+   WNRS, TableTopics •        |   • Facilitation decks (SessionLab,
+   (generic connection,       |     Synergy Stack) — method, not emotion
+    $18–30, one-time)         |
+                              |
+                          GENERIC
+```
+
+**WhoCards' wedge = the center:** AI-specific + emotionally honest + can be sold both as a
+low-touch product *and* laddered up to recurring team licenses and facilitated sessions.
+
+---
+
+## 4. Why WhoCards specifically can win this
+
+1. **The brand promise already is the product.** "Honest self-expression, active listening, deeper
+   connection" is the precise capability AI adoption is missing. No repositioning whiplash — it's a
+   focusing of what WhoCards already says.
+2. **The engine already exists.** The generalized `<Play>` component + SSR `/play` + programmatic
+   OG card generation means a new "AI @ Work" deck is mostly **content + a curated question set**,
+   not new infrastructure. Time-to-first-product is days, not months.
+3. **The roadmap already builds the monetization layer.** Issue #45 (accounts, favorites, custom
+   "decks," custom questions) is *exactly* what a B2B team product needs: org accounts, company-
+   branded/custom decks, a manager creating prompts for their team. We can re-justify #45 as the
+   revenue feature, not a nice-to-have.
+4. **Multilingual (14 languages).** Distributed/global teams are a real buyer; few competitors are
+   localized. This is a moat for international mid-market.
+
+---
+
+## 5. Product line — what to sell (laddered)
+
+Designed so each tier feeds the next and reuses existing tech.
+
+### Tier 0 — "The AI Check-In" — free digital deck (the wedge / lead magnet) — **advertise NOW**
+- 30–40 prompts a manager runs in a 20-minute team check-in: _"What's one task you'd hand to AI
+  tomorrow, and one you'd never want to?" · "What are you secretly worried AI means for your role?"
+  · "Where has AI already changed how you work this month?"_
+- Ships on the **existing `/play` engine** as a named deck (`/play?deck=ai-at-work`).
+- **Goal:** traffic + email capture + virality, not revenue. SEO ("AI team check-in questions,"
+  "how to talk to my team about AI") and LinkedIn are wide open — Cluster C only ranks for
+  "AI literacy."
+- **Cost to ship:** ~days. Pure content + one deck route.
+
+### Tier 1 — "Navigating AI Together" — paid deck (physical + digital) — **first revenue**
+- 100–150 cards across acts: _Name the Fear → Map the Work (human vs automatable) → Redesign the
+  Role → Team Norms for AI._ Includes a short **facilitator guide** (PDF) — that one addition moves
+  it from Cluster A ($18–30 toy) to Cluster B (professional tool, $39–69).
+- Sell physical decks (print-on-demand, the print pipeline exists) **and** a digital deck license.
+- **Buyers:** team managers, L&D, "AI champions." Bulk/wholesale for orgs (10+ decks).
+- **Price anchor:** $39–69 retail; bulk/org pricing per seat.
+
+### Tier 2 — "WhoCards for Teams" — recurring team license — **the real business (this is #45)**
+- Org accounts; company-branded and **custom decks**; managers author **custom questions**; saved
+  favorites; light cadence (a fresh AI-conversation pack monthly); a simple "what did the team
+  surface" view.
+- **This is literally issue #45.** Reframe and prioritize it as the SaaS monetization layer.
+- **Price anchor:** $5–10/seat/mo, or $1–3k/yr per team/org. Recurring → fixes the one-time-novelty
+  revenue problem that plagues Cluster A.
+
+### Tier 3 — "Navigating AI Together" facilitated session — services (margin + proof) — **optional**
+- A packaged half-day workshop using the deck (run by us or certified facilitators).
+- **Price anchor:** between Connect Facilitation's €1.2k and the $75k top end — land ~$2.5–6k.
+- Purpose isn't scale; it's **case studies, content validation, and logos** that sell Tiers 1–2.
+
+---
+
+## 6. Who buys it (ICP)
+
+- **Primary:** mid-market orgs (200–2,000 people) actively rolling out AI, where a People/L&D
+  leader, an "AI champion," or a transformation/Chief-AI lead owns adoption and is **failing on the
+  human side** (engagement, fear, shadow-AI use — 54% would use unauthorized tools).
+- **Secondary (bottom-up):** individual team managers who feel the tension and want a 20-minute tool
+  this week — they enter via Tier 0/1 and pull us into the org (PLG motion → Tier 2).
+- **Champion's pain we sell to:** "My AI rollout is stalling and I can't tell if it's resistance,
+  fear, or just confusion." We give them a safe, repeatable way to find out and move people.
+
+---
+
+## 7. Positioning & what to advertise
+
+**Core message:** _"Your AI rollout is stalling because of people, not tech. Start the conversation."_
+
+- Lead with the human/emotional angle — explicitly **not** "another AI tool" or another literacy
+  course. The decks make people *willing*; LMS/literacy makes them *capable*. We pair with, don't
+  compete with, Cluster C.
+- **First marketing moves (cheap, this quarter):**
+  1. Ship Tier 0 deck + a landing page targeting "talk to your team about AI" search intent (your
+     SEO research ticket #52 should prioritize these keywords).
+  2. LinkedIn content from the founder: the data in §2 + free prompts. This audience (L&D, People
+     Ops, managers) lives on LinkedIn and shares frameworks.
+  3. Lead magnet: "10 questions to run an AI check-in with your team" → email capture → Tier 1.
+  4. Partner outreach to AI-literacy vendors and facilitators (Cluster C/B) — we're the
+     complementary "willingness" layer to their "capability" content.
+
+---
+
+## 8. Risks & honest caveats
+
+- **Content credibility:** workplace/AI prompts must feel expert, not novelty. Mitigate with a
+  named advisor (an org-psych / change-mgmt voice) and the facilitator guide.
+- **B2B motion is new muscle.** WhoCards has sold decks, not seats/contracts. Tier 2/3 need a
+  sales/onboarding effort the team may not have yet — start with PLG (Tier 0→1) to learn the buyer
+  before committing to Tier 2 build-out.
+- **Trend timing:** AI-at-work is hot now; the deck must be evergreen enough to outlast the hype
+  cycle (frame around "change & human work," not specific 2026 tools).
+- **Incumbent fast-follow:** WNRS/TableTopics could ship an "AI edition." Our defensibility is the
+  multilingual engine + Tier 2 recurring/custom platform (#45), which a card company can't easily
+  match. Move on Tier 2 before the category gets crowded.
+
+---
+
+## 9. Recommended first 30 / 60 / 90 days
+
+- **30:** Write the Tier 0 "AI Check-In" question set; ship it on the `/play` engine as a named
+  deck + a dedicated landing page; start LinkedIn content. (Reuses existing infra — low cost.)
+- **60:** Validate demand from Tier 0 traffic/emails. Draft the Tier 1 deck (100–150 cards) +
+  facilitator guide; set up print-on-demand + digital purchase. Re-scope #45 as the Tier 2 product.
+- **90:** Launch Tier 1 paid deck. Run 1–2 pilot Tier 3 facilitated sessions with friendly orgs for
+  case studies. Decide go/no-go on building Tier 2 (the team license / #45) based on pilot signal.
+
+---
+
+## 10. How this maps to existing GitHub issues
+
+| Issue | Current framing | Strategic re-frame |
+|---|---|---|
+| **#45** accounts / favorites / custom decks / custom questions | feature epic | **Tier 2 SaaS monetization** — the recurring-revenue engine; re-prioritize |
+| **#52** SEO research | site polish | target "talk to your team about AI" / "AI team check-in" intent (Tier 0 funnel) |
+| generalized `<Play>` + `/play?deck=` | done | already supports per-deck routing for Tier 0/1 |
+| `/og` card generation | done | per-deck shareable social cards = free distribution for the wedge |
+
+---
+
+### Bottom line
+The cheapest, fastest, highest-leverage move is to **ship the free "AI Check-In" deck on the engine
+we already built and advertise the honest-conversation angle to L&D/managers on LinkedIn + SEO.**
+It costs days, tests the whole thesis, and — if it lands — the paid deck (Tier 1) and the team
+license that is already on the roadmap (#45 → Tier 2) are the revenue staircase behind it.

--- a/docs/strategy/ai-checkin-questions.md
+++ b/docs/strategy/ai-checkin-questions.md
@@ -1,0 +1,86 @@
+# AI Check-In — Question Content
+
+The free "AI Check-In" deck (Tier 0 from the AI-at-Work strategy). A short, manager-runnable
+deck that helps a team talk **honestly** about AI arriving in their work — the fear, the
+opportunity, what stays human, and the norms they want to live by.
+
+Tone is WhoCards: honest self-expression and connection. This is **not** an AI-literacy or
+"how to write prompts" deck. Every prompt is evergreen — it's about change and human work, not
+any specific tool, model, or year.
+
+- **Status:** English first. Translations into the other supported languages come later.
+- **Machine-usable map:** `src/data/decks/ai-at-work.questions.json` (English-only, same shape
+  as `src/data/questions.json`). The deck-wiring ticket can drop it in directly.
+- **Count:** 37 prompts across 4 acts.
+
+---
+
+## Facilitator note (for the manager)
+
+Run this as a 20-minute team check-in, not a workshop. Open by saying plainly that the point is
+honesty, not having the right answer, and that nothing said here counts against anyone. Pull
+**one card from each act in order** — Act 1 to surface the fear, Act 2 to look clearly at the
+work, Act 3 to imagine the upside, Act 4 to land on something concrete. Give roughly four
+minutes per act: ask the question, let people sit with it, then go around so every voice lands
+(quietest first if you can). You don't need to solve anything in the room — your job is to make
+it safe to say the quiet part out loud. Close on an Act 4 card and capture the one small
+agreement the team is willing to make today.
+
+---
+
+## Act 1 — Name the fear
+
+Surface what people are quietly carrying before talking solutions.
+
+- **ai-1** — What are you quietly worried AI might mean for your role?
+- **ai-2** — When you imagine your job five years from now, what feeling comes up first?
+- **ai-3** — What part of your work do you most hope a machine never touches?
+- **ai-4** — Is there something about AI at work you've been afraid to say out loud here?
+- **ai-5** — What were you proud to be good at that you wonder might matter less now?
+- **ai-6** — Where does the talk about AI leave you feeling excited rather than anxious?
+- **ai-7** — What would it take for you to feel safe, not threatened, by these changes?
+- **ai-8** — When you feel behind on all of this, who or what do you turn to?
+- **ai-9** — What's a rumour or assumption about AI and our jobs that you'd like to check out loud?
+
+## Act 2 — Map the work (human vs automatable)
+
+Look honestly at the job: what could be handed over, and what is unmistakably human.
+
+- **ai-10** — One task you would happily hand to AI tomorrow?
+- **ai-11** — One task you would never want to hand over, no matter how good the tools get?
+- **ai-12** — Which part of your work tires you out but doesn't really need you?
+- **ai-13** — Where in your week do you feel most irreplaceable?
+- **ai-14** — What does a good day at work actually look like for you, minute to minute?
+- **ai-15** — Which of your skills are about judgement, and which are about effort?
+- **ai-16** — What do people come to you for that a tool couldn't give them?
+- **ai-17** — Where do you secretly suspect we're doing work that doesn't need doing at all?
+- **ai-18** — What part of your job carries meaning for you beyond getting it done?
+
+## Act 3 — Redesign the role
+
+If the busywork goes, what does a better, more human version of the role look like?
+
+- **ai-19** — If the boring 30% of your job disappeared, what would you do with that time?
+- **ai-20** — What have you always wanted to do here but never had the hours for?
+- **ai-21** — If you could redesign your role from scratch, what would you keep?
+- **ai-22** — What would make you feel like you were growing again, not just keeping up?
+- **ai-23** — What's a skill you'd want to build if the work shifted under you?
+- **ai-24** — Where could you bring more of yourself to the work if the busywork were gone?
+- **ai-25** — What would "the best version of this job" look like a year from now?
+- **ai-26** — What's one thing you want to learn from someone else on this team?
+- **ai-27** — If we got an extra hour back each week, what would be the best way to spend it together?
+
+## Act 4 — Team norms for AI
+
+Land on shared agreements: when to use it, when not to, and how to stay honest with each other.
+
+- **ai-28** — When is it not okay to let AI do the work for us?
+- **ai-29** — What do we owe each other to be honest about when we use these tools?
+- **ai-30** — Where should a human always be the one to decide?
+- **ai-31** — What would make you trust a teammate's work even if a machine helped make it?
+- **ai-32** — When something goes wrong with AI-assisted work, how do we want to handle it as a team?
+- **ai-33** — What's a fear about AI you'd want this team to never dismiss?
+- **ai-34** — How do we make sure no one feels they have to hide that they're struggling to keep up?
+- **ai-35** — What should we promise each other before any of this changes how we work?
+- **ai-36** — Six months from now, how will we know we handled this change well?
+- **ai-37** — What's one small agreement we could make today that would help right now?

--- a/src/data/decks/ai-at-work.questions.json
+++ b/src/data/decks/ai-at-work.questions.json
@@ -1,0 +1,113 @@
+{
+  "ai-1": {
+    "en": "What are you quietly worried AI might mean for your role?"
+  },
+  "ai-2": {
+    "en": "When you imagine your job five years from now, what feeling comes up first?"
+  },
+  "ai-3": {
+    "en": "What part of your work do you most hope a machine never touches?"
+  },
+  "ai-4": {
+    "en": "Is there something about AI at work you've been afraid to say out loud here?"
+  },
+  "ai-5": {
+    "en": "What were you proud to be good at that you wonder might matter less now?"
+  },
+  "ai-6": {
+    "en": "Where does the talk about AI leave you feeling excited rather than anxious?"
+  },
+  "ai-7": {
+    "en": "What would it take for you to feel safe, not threatened, by these changes?"
+  },
+  "ai-8": {
+    "en": "When you feel behind on all of this, who or what do you turn to?"
+  },
+  "ai-9": {
+    "en": "What's a rumour or assumption about AI and our jobs that you'd like to check out loud?"
+  },
+  "ai-10": {
+    "en": "One task you would happily hand to AI tomorrow?"
+  },
+  "ai-11": {
+    "en": "One task you would never want to hand over, no matter how good the tools get?"
+  },
+  "ai-12": {
+    "en": "Which part of your work tires you out but doesn't really need you?"
+  },
+  "ai-13": {
+    "en": "Where in your week do you feel most irreplaceable?"
+  },
+  "ai-14": {
+    "en": "What does a good day at work actually look like for you, minute to minute?"
+  },
+  "ai-15": {
+    "en": "Which of your skills are about judgement, and which are about effort?"
+  },
+  "ai-16": {
+    "en": "What do people come to you for that a tool couldn't give them?"
+  },
+  "ai-17": {
+    "en": "Where do you secretly suspect we're doing work that doesn't need doing at all?"
+  },
+  "ai-18": {
+    "en": "What part of your job carries meaning for you beyond getting it done?"
+  },
+  "ai-19": {
+    "en": "If the boring 30% of your job disappeared, what would you do with that time?"
+  },
+  "ai-20": {
+    "en": "What have you always wanted to do here but never had the hours for?"
+  },
+  "ai-21": {
+    "en": "If you could redesign your role from scratch, what would you keep?"
+  },
+  "ai-22": {
+    "en": "What would make you feel like you were growing again, not just keeping up?"
+  },
+  "ai-23": {
+    "en": "What's a skill you'd want to build if the work shifted under you?"
+  },
+  "ai-24": {
+    "en": "Where could you bring more of yourself to the work if the busywork were gone?"
+  },
+  "ai-25": {
+    "en": "What would 'the best version of this job' look like a year from now?"
+  },
+  "ai-26": {
+    "en": "What's one thing you want to learn from someone else on this team?"
+  },
+  "ai-27": {
+    "en": "If we got an extra hour back each week, what would be the best way to spend it together?"
+  },
+  "ai-28": {
+    "en": "When is it not okay to let AI do the work for us?"
+  },
+  "ai-29": {
+    "en": "What do we owe each other to be honest about when we use these tools?"
+  },
+  "ai-30": {
+    "en": "Where should a human always be the one to decide?"
+  },
+  "ai-31": {
+    "en": "What would make you trust a teammate's work even if a machine helped make it?"
+  },
+  "ai-32": {
+    "en": "When something goes wrong with AI-assisted work, how do we want to handle it as a team?"
+  },
+  "ai-33": {
+    "en": "What's a fear about AI you'd want this team to never dismiss?"
+  },
+  "ai-34": {
+    "en": "How do we make sure no one feels they have to hide that they're struggling to keep up?"
+  },
+  "ai-35": {
+    "en": "What should we promise each other before any of this changes how we work?"
+  },
+  "ai-36": {
+    "en": "Six months from now, how will we know we handled this change well?"
+  },
+  "ai-37": {
+    "en": "What's one small agreement we could make today that would help right now?"
+  }
+}


### PR DESCRIPTION
Closes #56

Authors the **content** for the free "AI Check-In" deck (Tier 0 from the AI-at-Work strategy). Content only — wiring into the app is a separate ticket.

## What's here
- **37 evergreen prompts** across the 4 strategy acts, in WhoCards tone (honest self-expression, not AI-literacy).
- `src/data/decks/ai-at-work.questions.json` — English-only map in the same shape as `questions.json`, keys `ai-1`..`ai-37`. Deck-wiring can drop it straight in.
- `docs/strategy/ai-checkin-questions.md` — grouped-by-act human-readable list + a 1-paragraph facilitator note for running a 20-min check-in.

## Acts
1. **Name the fear** (ai-1..9)
2. **Map the work** — human vs automatable (ai-10..18)
3. **Redesign the role** (ai-19..27)
4. **Team norms for AI** (ai-28..37)

English first; translations into other supported languages follow later.